### PR TITLE
Add Jib Maven plugin for containerizing services

### DIFF
--- a/backend_microservices/booking-service/pom.xml
+++ b/backend_microservices/booking-service/pom.xml
@@ -104,6 +104,16 @@
 					</excludes>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>com.google.cloud.tools</groupId>
+				<artifactId>jib-maven-plugin</artifactId>
+				<version>3.4.5</version>
+				<configuration>
+					<to>
+						<image>ritikdevcode/salon-booking-service:v1</image>
+					</to>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/backend_microservices/category-service/pom.xml
+++ b/backend_microservices/category-service/pom.xml
@@ -108,6 +108,16 @@
 					</excludes>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>com.google.cloud.tools</groupId>
+				<artifactId>jib-maven-plugin</artifactId>
+				<version>3.4.5</version>
+				<configuration>
+					<to>
+						<image>ritikdevcode/salon-category-service:v1</image>
+					</to>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/backend_microservices/eureka-server/pom.xml
+++ b/backend_microservices/eureka-server/pom.xml
@@ -60,6 +60,16 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>com.google.cloud.tools</groupId>
+				<artifactId>jib-maven-plugin</artifactId>
+				<version>3.4.5</version>
+				<configuration>
+					<to>
+						<image>ritikdevcode/salon-eureka-server:v1</image>
+					</to>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/backend_microservices/gateway-server/pom.xml
+++ b/backend_microservices/gateway-server/pom.xml
@@ -75,6 +75,16 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>com.google.cloud.tools</groupId>
+				<artifactId>jib-maven-plugin</artifactId>
+				<version>3.4.5</version>
+				<configuration>
+					<to>
+						<image>ritikdevcode/salon-gateway-server:v1</image>
+					</to>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/backend_microservices/payment-service/pom.xml
+++ b/backend_microservices/payment-service/pom.xml
@@ -109,6 +109,16 @@
 					</excludes>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>com.google.cloud.tools</groupId>
+				<artifactId>jib-maven-plugin</artifactId>
+				<version>3.4.5</version>
+				<configuration>
+					<to>
+						<image>ritikdevcode/salon-payment-service:v1</image>
+					</to>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/backend_microservices/salon-service/pom.xml
+++ b/backend_microservices/salon-service/pom.xml
@@ -108,6 +108,16 @@
 					</excludes>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>com.google.cloud.tools</groupId>
+				<artifactId>jib-maven-plugin</artifactId>
+				<version>3.4.5</version>
+				<configuration>
+					<to>
+						<image>ritikdevcode/salon-service:v1</image>
+					</to>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/backend_microservices/service-offering/pom.xml
+++ b/backend_microservices/service-offering/pom.xml
@@ -108,6 +108,16 @@
 					</excludes>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>com.google.cloud.tools</groupId>
+				<artifactId>jib-maven-plugin</artifactId>
+				<version>3.4.5</version>
+				<configuration>
+					<to>
+						<image>ritikdevcode/salon-service-offering:v1</image>
+					</to>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/backend_microservices/user-service/pom.xml
+++ b/backend_microservices/user-service/pom.xml
@@ -88,6 +88,16 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>com.google.cloud.tools</groupId>
+				<artifactId>jib-maven-plugin</artifactId>
+				<version>3.4.5</version>
+				<configuration>
+					<to>
+						<image>ritikdevcode/salon-user:v1</image>
+					</to>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Added the Jib Maven plugin (v3.4.5) to all service modules for building and pushing Docker images. Each service is configured with its respective image name and version, streamlining the containerization process. This change improves the CI/CD workflow by automating image creation and deployment.